### PR TITLE
Bug fix: stateless execution with all events

### DIFF
--- a/utils/lttng-simple
+++ b/utils/lttng-simple
@@ -123,18 +123,18 @@ def do_trace(cmd, session, options, kernel, ust):
     add_context = False
     if (kernel):
         cmd_stub([LTTNG, "enable-channel", "k", "-k", "--subbuf-size", "16384", "--num-subbuf", "4096"], True)
+        evlist = load_event_list(options.evlist)
+        # enable pid/tid context if there is no sched_switch event
+        if (not "sched_switch" in evlist or options.stateless):
+            add_context = True
+            cmd_stub([LTTNG, "add-context", "-k", "-c", "k", "-t", "pid", "-t", "tid", "-t", "procname"], True)
         if (options.syscall):
             cmd_stub([LTTNG, "enable-event", "-c", "k", "-a", "-k", "--syscall"], True)
         if (options.evlist is None or options.enable_all_events):
             cmd_stub([LTTNG, "enable-event", "-c", "k", "-a", "-k"], True)
         else:
-            evlist = load_event_list(options.evlist)
             for ev in evlist:
                 cmd_stub([LTTNG, "enable-event", "-k", "-c", "k", ev], True)
-            # enable pid/tid context if there is no sched_switch event
-            if (not "sched_switch" in evlist or options.stateless):
-                add_context = True
-                cmd_stub([LTTNG, "add-context", "-k", "-c", "k", "-t", "pid", "-t", "tid", "-t", "procname"], True)
     if (ust):
         cmd_stub([LTTNG, "enable-channel", "u", "-u", "--subbuf-size", "4096", "--num-subbuf", "4096"], True)
         cmd_stub([LTTNG, "enable-event", "-c", "u", "-a", "-u"], True)
@@ -183,10 +183,10 @@ if __name__=="__main__":
     parser.add_option("-n", "--dry-run", dest="dry_run", default=False, action="store_true", help="Do not execute commands")
     parser.add_option("-e", "--enable-event-list", dest="evlist", default=default_evlist, help="White list of events to enable")
     parser.add_option("--list-profiles", dest="list_profiles", default=False, action="store_true", help="List event profiles")
-    parser.add_option("-a", "--all", dest="enable_all_events", default=False, help="Enable all events")
+    parser.add_option("-a", "--all", dest="enable_all_events", default=False, action="store_true", help="Enable all events")
     parser.add_option("--enable-libc-wrapper", dest="libc_wrapper", default=False, action="store_true", help="Enable UST libc wrapper")
     parser.add_option("-s", "--syscall", dest="syscall", default=False, action="store_true", help="Enable syscall tracing")
-    parser.add_option("--stateless", dest="stateless", default=False, action="store_true", help="Enable pid/tid context for stateless trace processing")
+    parser.add_option("--stateless", dest="stateless", default=False, action="store_true", help="Enable pid/tid/procname context for stateless trace processing")
     parser.add_option("--name", dest="name", metavar="NAME", default=None, help="trace output name (default to command name with k/u suffix)")
     parser.add_option("-c", "--clear", dest="clear_trace", default=False, action="store_true", help="Remove previous trace if exists")
     parser.add_option("-v", "--verbose", dest="verbose", default=False, action="store_true", help="Verbose mode")


### PR DESCRIPTION
With -a/--all flag, the stateless option was ignored.

Signed-off-by: Mohamad Gebai mohamad.gebai@polymtl.ca
